### PR TITLE
Drop the dependency on external RPC headers

### DIFF
--- a/ApMon.h
+++ b/ApMon.h
@@ -91,12 +91,12 @@
 #include <stdexcept>
 #include <ctype.h>
 #include <time.h>
+#include "xdr.h"
 
 #ifdef WIN32
 #include <Winsock2.h>
 #include <string.h>
 #include <process.h>
-#include "xdr.h"
 
 #else
 #include <sys/socket.h>
@@ -106,7 +106,6 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <net/if.h>
-#include <rpc/rpc.h>
 #include <netdb.h>
 #include <unistd.h>
 #include <pthread.h>

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ endif
 AM_CXXFLAGS = 
 INCLUDES = -I./ 
 lib_LTLIBRARIES = libapmoncpp.la
-include_HEADERS = ApMon.h utils.h monitor_utils.h proc_utils.h mon_constants.h xdr.h
+include_HEADERS = ApMon.h utils.h monitor_utils.h proc_utils.h mon_constants.h xdr.h types.h
 
 libapmoncpp_la_SOURCES = ApMon.cpp utils.cpp monitor_utils.cpp proc_utils.cpp mon_constants.cpp xdr.cpp
 

--- a/config.h.in
+++ b/config.h.in
@@ -16,49 +16,49 @@
 #undef HAVE_INTTYPES_H
 
 /* Define to 1 if you have the <limits.h> header file. */
-#undef HAVE_LIMITS_H
+#define HAVE_LIMITS_H 1
 
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
 /* Define to 1 if you have the <netdb.h> header file. */
-#undef HAVE_NETDB_H
+#define HAVE_NETDB_H 1
 
 /* Define to 1 if you have the <netinet/in.h> header file. */
-#undef HAVE_NETINET_IN_H
+#define HAVE_NETINET_IN_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#undef HAVE_STDLIB_H
+#define HAVE_STDLIB_H 1
 
 /* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H
 
 /* Define to 1 if you have the <string.h> header file. */
-#undef HAVE_STRING_H
+#define HAVE_STRING_H 1
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
-#undef HAVE_SYS_SOCKET_H
+#define HAVE_SYS_SOCKET_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#undef HAVE_SYS_STAT_H
+#define HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/timeb.h> header file. */
 #undef HAVE_SYS_TIMEB_H
 
 /* Define to 1 if you have the <sys/time.h> header file. */
-#undef HAVE_SYS_TIME_H
+#define HAVE_SYS_TIME_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#undef HAVE_SYS_TYPES_H
+#define HAVE_SYS_TYPES_H 1
 
 /* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
-#undef HAVE_SYS_WAIT_H
+#define HAVE_SYS_WAIT_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#undef HAVE_UNISTD_H
+#define HAVE_UNISTD_H 1
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */

--- a/types.h
+++ b/types.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2010, Oracle America, Inc.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *     * Neither the name of the "Oracle America, Inc." nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *   COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ *   GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/* fixincludes should not add extern "C" to this file */
+/*
+ * Rpc additions to <sys/types.h>
+ */
+#ifndef _RPC_TYPES_H
+#define _RPC_TYPES_H 1
+
+typedef int bool_t;
+typedef int enum_t;
+/* This needs to be changed to uint32_t in the future */
+typedef unsigned long rpcprog_t;
+typedef unsigned long rpcvers_t;
+typedef unsigned long rpcproc_t;
+typedef unsigned long rpcprot_t;
+typedef unsigned long rpcport_t;
+
+#define        __dontcare__    -1
+
+#ifndef FALSE
+#      define  FALSE   (0)
+#endif
+
+#ifndef TRUE
+#      define  TRUE    (1)
+#endif
+
+#ifndef NULL
+#      define  NULL 0
+#endif
+
+#include <stdlib.h>		/* For malloc decl.  */
+#define mem_alloc(bsize)	malloc(bsize)
+/*
+ * XXX: This must not use the second argument, or code in xdr_array.c needs
+ * to be modified.
+ */
+#define mem_free(ptr, bsize)	free(ptr)
+
+#ifndef makedev /* ie, we haven't already included it */
+#include <sys/types.h>
+#endif
+
+#if defined __APPLE_CC__ || defined __FreeBSD__
+# define __u_char_defined
+# define __daddr_t_defined
+#endif
+
+#ifndef __u_char_defined
+typedef __u_char u_char;
+typedef __u_short u_short;
+typedef __u_int u_int;
+typedef __u_long u_long;
+typedef __quad_t quad_t;
+typedef __u_quad_t u_quad_t;
+typedef __fsid_t fsid_t;
+# define __u_char_defined
+#endif
+#ifndef __daddr_t_defined
+typedef __daddr_t daddr_t;
+typedef __caddr_t caddr_t;
+# define __daddr_t_defined
+#endif
+
+#include <sys/time.h>
+#include <sys/param.h>
+
+#include <netinet/in.h>
+
+#ifndef INADDR_LOOPBACK
+#define       INADDR_LOOPBACK         (u_long)0x7F000001
+#endif
+#ifndef MAXHOSTNAMELEN
+#define        MAXHOSTNAMELEN  64
+#endif
+
+#endif /* rpc/types.h */

--- a/xdr.cpp
+++ b/xdr.cpp
@@ -112,10 +112,10 @@ xdr_int(XDR *xdrs, int *ip)
 
 #ifdef lint
         (void) (xdr_short(xdrs, (short *)ip));
-        return (xdr_long(xdrs, (long *)ip));
+        return (xdr_long(xdrs, (uint32_t *)ip));
 #else
         if (sizeof (int) == sizeof (long)) {
-                return (xdr_long(xdrs, (long *)ip));
+                return (xdr_long(xdrs, (uint32_t *)ip));
         } else {
                 return (xdr_short(xdrs, (short *)ip));
         }
@@ -127,8 +127,9 @@ xdr_int(XDR *xdrs, int *ip)
  * same as xdr_u_long - open coded to save a proc call!
  */
 bool_t
-xdr_long(register XDR *xdrs, long *lp)
+xdr_long(register XDR *xdrs, uint32_t *lp)
 {
+	printf("long\n");
 
         if (xdrs->x_op == XDR_ENCODE)
                 return (XDR_PUTLONG(xdrs, lp));
@@ -147,13 +148,13 @@ xdr_long(register XDR *xdrs, long *lp)
  * same as xdr_long - open coded to save a proc call!
  */
 bool_t
-xdr_u_long(register XDR *xdrs, u_long *ulp)
+xdr_u_long(register XDR *xdrs, uint32_t *ulp)
 {
 
         if (xdrs->x_op == XDR_DECODE)
-                return (XDR_GETLONG(xdrs, (long *)ulp));
+                return (XDR_GETLONG(xdrs, (uint32_t *)ulp));
         if (xdrs->x_op == XDR_ENCODE)
-                return (XDR_PUTLONG(xdrs, (long *)ulp));
+                return (XDR_PUTLONG(xdrs, (uint32_t *)ulp));
         if (xdrs->x_op == XDR_FREE)
                 return (TRUE);
         return (FALSE);
@@ -165,12 +166,12 @@ xdr_u_long(register XDR *xdrs, u_long *ulp)
 bool_t
 xdr_short(register XDR *xdrs, short *sp)
 {
-        long l;
+        uint32_t l;
 
         switch (xdrs->x_op) {
 
         case XDR_ENCODE:
-                l = (long) *sp;
+                l = (uint32_t) *sp;
                 return (XDR_PUTLONG(xdrs, &l));
 
         case XDR_DECODE:
@@ -192,12 +193,12 @@ xdr_short(register XDR *xdrs, short *sp)
 bool_t
 xdr_u_short(register XDR *xdrs, u_short *usp)
 {
-        long l;
+        uint32_t l;
 
         switch (xdrs->x_op) {
 
         case XDR_ENCODE:
-                l = (long) *usp;
+                l = (uint32_t) *usp;
                 return (XDR_PUTLONG(xdrs, &l));
 
         case XDR_DECODE:
@@ -222,10 +223,10 @@ xdr_u_int(XDR *xdrs, u_int *up)
 
 #ifdef lint
         (void) (xdr_short(xdrs, (short *)up));
-        return (xdr_u_long(xdrs, (u_long *)up));
+        return (xdr_u_long(xdrs, (uint32_t *)up));
 #else
         if (sizeof (u_int) == sizeof (u_long)) {
-                return (xdr_u_long(xdrs, (u_long *)up));
+                return (xdr_u_long(xdrs, (uint32_t *)up));
         } else {
                 return (xdr_short(xdrs, (short *)up));
         }
@@ -351,9 +352,9 @@ xdr_float(register XDR *xdrs, register float *fp)
 {
         switch (xdrs->x_op) {
         case XDR_ENCODE:
-                return (XDR_PUTLONG(xdrs, (long *)fp));
+                return (XDR_PUTLONG(xdrs, (uint32_t *)fp));
         case XDR_DECODE:
-                return (XDR_GETLONG(xdrs, (long *)fp));
+                return (XDR_GETLONG(xdrs, (uint32_t *)fp));
         case XDR_FREE:
                 return (TRUE);
         }
@@ -363,14 +364,14 @@ xdr_float(register XDR *xdrs, register float *fp)
 bool_t
 xdr_double(register XDR *xdrs, double *dp)
 {
-        register long *lp;
+        register uint32_t *lp;
 
         switch (xdrs->x_op) {
         case XDR_ENCODE:
-                lp = (long *)dp;
+                lp = (uint32_t *)dp;
                 return (XDR_PUTLONG(xdrs, lp+1) && XDR_PUTLONG(xdrs, lp));
         case XDR_DECODE:
-                lp = (long *)dp;
+                lp = (uint32_t *)dp;
                 return (XDR_GETLONG(xdrs, lp+1) && XDR_GETLONG(xdrs, lp));
         case XDR_FREE:
                 return (TRUE);
@@ -382,8 +383,8 @@ xdr_double(register XDR *xdrs, double *dp)
 /************************* XDR operations with memory buffers **************************/
 
 void xdrmem_destroy(void *);
-bool_t xdrmem_getlong(void *xdrs, long *lp);
-bool_t xdrmem_putlong(void *xdrs, long *lp);
+bool_t xdrmem_getlong(void *xdrs, uint32_t *lp);
+bool_t xdrmem_putlong(void *xdrs, uint32_t *lp);
 bool_t xdrmem_getbytes(void *xdrs, void *addr, register int len);
 bool_t xdrmem_putbytes(void *xdrs, void *addr, register int len);
 u_int  xdrmem_getpos(void *xdrs);
@@ -421,26 +422,25 @@ xdrmem_destroy(void *xdrs)
 }
 
 bool_t
-xdrmem_getlong(void *xdrsv, long *lp)
+xdrmem_getlong(void *xdrsv, uint32_t *lp)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
-        if ((xdrs->x_handy -= sizeof(long)) < 0)
+        if ((xdrs->x_handy -= sizeof(uint32_t)) < 0)
                 return (FALSE);
         *lp = (long)ntohl((u_long)(*((long *)(xdrs->x_private))));
-        xdrs->x_private += sizeof(long);
+        xdrs->x_private += sizeof(uint32_t);
         return (TRUE);
 }
 
 bool_t
-xdrmem_putlong(void *xdrsv, long *lp)
+xdrmem_putlong(void *xdrsv, uint32_t *lp)
 {
 
 		register XDR *xdrs = (XDR *)xdrsv;
-        if ((xdrs->x_handy -= sizeof(long)) < 0)
-                return (FALSE);
-        *(long *)xdrs->x_private = (long)htonl((u_long)(*lp));
-        xdrs->x_private += sizeof(long);
-        return (TRUE);
+
+	uint32_t value = htonl((uint32_t) (*lp));
+
+	return xdrmem_putbytes(xdrsv, &value, sizeof(uint32_t));
 }
 
 bool_t
@@ -469,7 +469,7 @@ u_int
 xdrmem_getpos(void *xdrsv)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
-        return xdrs->x_private - xdrs->x_base;
+        return (u_int) ((u_long)xdrs->x_private - (u_long)xdrs->x_base);
 }
 
 bool_t
@@ -482,7 +482,7 @@ xdrmem_setpos(void *xdrsv, int pos)
         if ((long)newaddr > (long)lastaddr)
                 return (FALSE);
         xdrs->x_private = newaddr;
-        xdrs->x_handy = lastaddr - newaddr;
+        xdrs->x_handy = (int) (lastaddr - newaddr);
         return (TRUE);
 }
 

--- a/xdr.cpp
+++ b/xdr.cpp
@@ -40,9 +40,6 @@
  * Mountain View, California  94043
  */
 
-/** This is only for WINDOWS. Linux and Mac already have this in <rpc/rpc.h> */
-#ifdef WIN32
-
 #if !defined(lint) && defined(SCCSIDS)
 static char sccsid[] = "@(#)xdr.c 1.35 87/08/12";
 #endif
@@ -61,7 +58,12 @@ static char sccsid[] = "@(#)xdr.c 1.35 87/08/12";
 #include <stdlib.h>             /* malloc,free */
 #include <string.h>             /* strlen() */
 
+#ifdef WIN32
 #include <Winsock2.h>
+#else
+#include <netinet/in.h>
+#endif
+
 #include "xdr.h"
 
 /*
@@ -239,7 +241,7 @@ bool_t
 xdr_opaque(register XDR *xdrs, caddr_t cp, register u_int cnt)
 {
         register u_int rndup;
-        static crud[BYTES_PER_XDR_UNIT];
+        static char* crud[BYTES_PER_XDR_UNIT];
 
         /*
          * if no data we are done
@@ -413,12 +415,12 @@ xdrmem_create(register XDR *xdrs, caddr_t addr, u_int size, enum xdr_op op)
         xdrs->x_handy = size;
 }
 
-static void
+void
 xdrmem_destroy(void *xdrs)
 {
 }
 
-static bool_t
+bool_t
 xdrmem_getlong(void *xdrsv, long *lp)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
@@ -429,7 +431,7 @@ xdrmem_getlong(void *xdrsv, long *lp)
         return (TRUE);
 }
 
-static bool_t
+bool_t
 xdrmem_putlong(void *xdrsv, long *lp)
 {
 
@@ -441,7 +443,7 @@ xdrmem_putlong(void *xdrsv, long *lp)
         return (TRUE);
 }
 
-static bool_t
+bool_t
 xdrmem_getbytes(void *xdrsv, void *addr, register int len)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
@@ -452,7 +454,7 @@ xdrmem_getbytes(void *xdrsv, void *addr, register int len)
         return (TRUE);
 }
 
-static bool_t
+bool_t
 xdrmem_putbytes(void *xdrsv, void *addr, register int len)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
@@ -463,14 +465,14 @@ xdrmem_putbytes(void *xdrsv, void *addr, register int len)
         return (TRUE);
 }
 
-static u_int
+u_int
 xdrmem_getpos(void *xdrsv)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
-        return ((u_int)xdrs->x_private - (u_int)xdrs->x_base);
+        return xdrs->x_private - xdrs->x_base;
 }
 
-static bool_t
+bool_t
 xdrmem_setpos(void *xdrsv, int pos)
 {
 		register XDR *xdrs = (XDR *)xdrsv;
@@ -480,11 +482,11 @@ xdrmem_setpos(void *xdrsv, int pos)
         if ((long)newaddr > (long)lastaddr)
                 return (FALSE);
         xdrs->x_private = newaddr;
-        xdrs->x_handy = (int)lastaddr - (int)newaddr;
+        xdrs->x_handy = lastaddr - newaddr;
         return (TRUE);
 }
 
-static long *
+long *
 xdrmem_inline(void *xdrsv, int len)
 {
         long *buf = 0;
@@ -496,5 +498,3 @@ xdrmem_inline(void *xdrsv, int len)
         }
         return (buf);
 }
-
-#endif  /* WIN32 */

--- a/xdr.h
+++ b/xdr.h
@@ -156,8 +156,8 @@ enum xdr_op {
 typedef struct {
         enum xdr_op     x_op;           /* operation; fast additional param */
         struct xdr_ops {
-                bool_t  (*x_getlong)(void *, long *);   /* get a long from underlying stream */
-                bool_t  (*x_putlong)(void *, long *);   /* put a long to " */
+                bool_t  (*x_getlong)(void *, uint32_t *);   /* get a long from underlying stream */
+                bool_t  (*x_putlong)(void *, uint32_t *);   /* put a long to " */
                 bool_t  (*x_getbytes)(void *, void *, int );/* get some bytes from " */
                 bool_t  (*x_putbytes)(void *, void *, int);/* put some bytes to " */
                 u_int   (*x_getpostn)(void *);/* returns bytes off from beginning */
@@ -320,7 +320,7 @@ void xdrmem_create(XDR *xdrs, caddr_t addr, u_int size, enum xdr_op op);
 
 bool_t xdr_int(XDR *, int *);
 
-bool_t xdr_long(XDR *, long *);
+bool_t xdr_long(XDR *, uint32_t *);
 
 bool_t xdr_short(XDR *, short *);
 

--- a/xdr.h
+++ b/xdr.h
@@ -47,9 +47,6 @@
  * Copyright (C) 1984, Sun Microsystems, Inc.
  */
 
-/** This is only for WINDOWS. Linux and Mac already have this in <rpc/rpc.h> */
-#ifdef WIN32	
-
 #ifndef __XDR_HEADER__
 #define __XDR_HEADER__
 
@@ -405,5 +402,3 @@ extern bool_t xdrrec_skiprecord();      /* move to beginning of next record *
 extern bool_t xdrrec_eof();             /* true if no more input */
 
 #endif /* __XDR_HEADER__ */
-
-#endif /* WIN32 */


### PR DESCRIPTION
The library already had an internal support for xdr format encoding. It was however only used on Win. This commit changes this behavior, always using it and thus not depending on the rpc/rpc.h to provide the encoding functions.