### PR TITLE
Add missing cstdint include

### DIFF
--- a/xdr.h
+++ b/xdr.h
@@ -152,6 +152,7 @@ enum xdr_op {
  */
 
 #ifdef __cplusplus
+#include <cstdint>
 
 typedef struct {
         enum xdr_op     x_op;           /* operation; fast additional param */


### PR DESCRIPTION
Required for compilation with gcc 13.2 on ubuntu 23.10